### PR TITLE
Follow Linux Standard Base exit codes for init script actions

### DIFF
--- a/pandora_server/util/pandora_server
+++ b/pandora_server/util/pandora_server
@@ -42,11 +42,16 @@ then
 	. /etc/rc.status
 	rc_reset
 else
-	# Define rc functions for non-suse systems, "void" functions.
-	function rc_status () { VOID=1; }
-	function rc_exit () { exit; }
-	function rc_failed () { VOID=1; }
-
+	# Define part of rc functions for non-suse systems
+	function rc_status () {
+		RETVAL=$?
+		case $1 in
+			-v) RETVAL=0;;
+		esac
+	}
+	function rc_exit () { exit $RETVAL; }
+	function rc_failed () { RETVAL=${1:-1}; }
+	RETVAL=0
 fi
 	
 # This function replace pidof, not working in the same way in different linux distros

--- a/pandora_server/util/pandora_server
+++ b/pandora_server/util/pandora_server
@@ -65,7 +65,7 @@ function pidof_pandora () {
 if [ ! -f $PANDORA_DAEMON ]
 then
 	echo "Pandora FMS Server not found, please check setup and read manual"
-	rc_status -s
+	rc_failed 5 # program is not installed
 	rc_exit
 fi
 
@@ -74,9 +74,8 @@ case "$1" in
 		PANDORA_PID=`pidof_pandora`
 		if [ ! -z "$PANDORA_PID" ]
 		then
-			echo "Pandora FMS Server is currently running on this machine with PID ($PANDORA_PID). Aborting now..."
-			rc_failed 1
-			rc_exit 
+			echo "Pandora FMS Server is currently running on this machine with PID ($PANDORA_PID)."
+			rc_exit # running start on a service already running
 		fi
 	
 		$PANDORA_DAEMON $PANDORA_HOME -D
@@ -91,7 +90,7 @@ case "$1" in
 		else
 			echo "Cannot start Pandora FMS Server. Aborted."
 			echo "Check Pandora FMS log files at '/var/log/pandora/pandora_server.error & pandora_server.log'"
-			rc_status -s
+			rc_failed 7 # program is not running
 		fi
 	;;
 		
@@ -100,7 +99,7 @@ case "$1" in
 		if [ -z "$PANDORA_PID" ]
 		then
 			echo "Pandora FMS Server is not running, cannot stop it."
-			rc_failed 
+			rc_exit # running stop on a service already stopped or not running
 		else
 			echo "Stopping Pandora FMS Server"
 			kill $PANDORA_PID > /dev/null 2>&1
@@ -131,7 +130,7 @@ case "$1" in
 		if [ -z "$PANDORA_PID" ]
 		then
 			echo "Pandora FMS Server is not running."
-			rc_status 
+			rc_failed 7 # program is not running
 		else
 			echo "Pandora FMS Server is running with PID $PANDORA_PID."
 			rc_status

--- a/pandora_server/util/pandora_server
+++ b/pandora_server/util/pandora_server
@@ -51,14 +51,14 @@ fi
 	
 # This function replace pidof, not working in the same way in different linux distros
 
-function pidof_pandora () (
+function pidof_pandora () {
 	# This sets COLUMNS to XXX chars, because if command is run 
 	# in a "strech" term, ps aux don't report more than COLUMNS
 	# characters and this will not work. 
 	COLUMNS=300
 	PANDORA_PID=`ps aux | grep "$PANDORA_DAEMON $PANDORA_HOME" | grep -v grep | tail -1 | awk '{ print $2 }'`
 	echo $PANDORA_PID
-)
+}
 
 # Main script
 
@@ -106,7 +106,7 @@ case "$1" in
 			kill $PANDORA_PID > /dev/null 2>&1
 			COUNTER=0
 
-		while [ $COUNTER -lt $MAXWAIT ]
+			while [ $COUNTER -lt $MAXWAIT ]
 	 		do
  				_PID=`pidof_pandora`
 				if [ "$_PID" != "$PANDORA_PID" ]

--- a/pandora_server/util/tentacle_serverd
+++ b/pandora_server/util/tentacle_serverd
@@ -77,7 +77,7 @@ esac
 
 if [ ! -f "${TENTACLE_PATH}$TENTACLE_DAEMON" ]; then
 	echo "Tentacle Server not found in ${TENTACLE_PATH}$TENTACLE_DAEMON"
-	rc_failed 1
+	rc_failed 5 # program is not installed
 	rc_exit
 fi
 
@@ -86,8 +86,7 @@ case "$1" in
 		TENTACLE_PID=`get_pid`
 		if [ ! -z "$TENTACLE_PID" ]; then
 			echo "Tentacle Server is already running with PID $TENTACLE_PID"
-			rc_failed 2
-			rc_exit	
+			rc_exit	# running start on a service already running
 		fi
 	
 		sudo -u $TENTACLE_USER ${TENTACLE_PATH}$TENTACLE_DAEMON $TENTACLE_OPTS
@@ -100,7 +99,7 @@ case "$1" in
 		else
 			echo "Tentacle Server could not be started."
 			echo "Verify that port $TENTACLE_PORT is not used."
-			rc_status -v
+			rc_failed 7 # program not running
 		fi
 
 	;;
@@ -109,7 +108,7 @@ case "$1" in
 		TENTACLE_PID=`get_pid`
 		if [ -z "$TENTACLE_PID" ]; then
 			echo "Tentacle Server does not seem to be running"
-			rc_failed 2
+			rc_exit # running stop on a service already stopped or not running
 		else
 			kill $TENTACLE_PID
 			sleep 1
@@ -117,7 +116,7 @@ case "$1" in
 
 			if [ "$_PID" = "$TENTACLE_PID" ]; then
 				echo "Tentacle Server could not be stopped"
-				rc_status -s
+				rc_failed
 			fi
 
 			echo "Stopping Tentacle Server"
@@ -137,7 +136,7 @@ case "$1" in
 		TENTACLE_PID=`get_pid`
 		if [ -z "$TENTACLE_PID" ]; then
 			echo "Tentacle Server is not running."
-			rc_status 
+			rc_failed 7 # program is not running
 		else
 			echo "Tentacle Server is running with PID $TENTACLE_PID."
 			rc_status 

--- a/pandora_server/util/tentacle_serverd
+++ b/pandora_server/util/tentacle_serverd
@@ -30,11 +30,16 @@ then
 	. /etc/rc.status
 	rc_reset
 else
-	# Define rc functions for non-suse systems, "void" functions.
-	function rc_status () { VOID=1; }
-	function rc_exit () { exit; }
-	function rc_failed () { VOID=1; }
-
+	# Define part of rc functions for non-suse systems
+	function rc_status () {
+		RETVAL=$?
+		case $1 in
+			-v) RETVAL=0;;
+		esac
+	}
+	function rc_exit () { exit $RETVAL; }
+	function rc_failed () { RETVAL=${1:-1}; }
+	RETVAL=0
 fi
 
 function get_pid {


### PR DESCRIPTION
This pull request contains changes to make init scripts, pandora_server and tentacle_serverd, [LSB (Linux Standard Base) Init Script Actions](http://refspecs.linuxbase.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html) compatible.

Some configuration management systems, for example puppet and ansible, expects these LSB init script behavior to check whether service is started or not, consult [puppet service status check code](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/type/service.rb#L184-L197) and [ansible service status check code](https://github.com/ansible/ansible-modules-core/blob/devel/system/service.py#L586-L593) for detailed information.

One may concern that this PR breaks backward compatibility on SuSE platform, but it seems less important.
For other Linux platform, init scripts always exited with 0, so no one cares.

Additional References
- [Packaging:SysVInitScript - Fedora Project](http://fedoraproject.org/wiki/Packaging:SysVInitScript)
- [openSUSE:Packaging init scripts - OpenSUSE Project](https://en.opensuse.org/openSUSE:Packaging_init_scripts)

Regards
