### PR TITLE
Enable to postpone planned downtime when in execution and its type is once

### DIFF
--- a/pandora_console/godmode/agentes/planned_downtime.list.php
+++ b/pandora_console/godmode/agentes/planned_downtime.list.php
@@ -499,6 +499,12 @@ else {
 				'delete_downtime=1&amp;id_downtime='.$downtime['id'].'">' .
 			html_print_image("images/cross.png", true, array("border" => '0', "alt" => __('Delete')));
 		}
+		elseif ($downtime["executed"] == 1 && $downtime['type_execution'] == 'once'){
+			$data[8] = '<a href="index.php?sec=estado&amp;sec2=godmode/agentes/planned_downtime.editor&amp;' .
+				'edit_downtime=1&amp;id_downtime='.$downtime['id'].'">' .
+			html_print_image("images/config.png", true, array("border" => '0', "alt" => __('Update'))) . '</a>';
+			$data[9]= "N/A";
+		}
 		else {
 			$data[8]= "N/A";
 			$data[9]= "N/A";


### PR DESCRIPTION
Hi, all.

We sometimes coincide cases that maintenance unexpectedly being overdue periods.

This pull request adds ability to postpone planned downtime when it is in execution and its type is once.
In other cases, changing other values, such that start time or maintenance targets are explicitly inhibited and giving a constraint that planned downtime is once, because we think the change on other values or on periodic planned downtime have profound effects.

I noticed that the update on planned downtime documents is required after merged, so I'll update documents.

This pull request is originally suggested Hiroki Shimizu and based on his contribution.

Regards. 
