### PR TITLE
Evade zero division PHP Warning due to huge $Value2

### DIFF
--- a/pandora_console/include/graphs/pChart/pDraw.class.php
+++ b/pandora_console/include/graphs/pChart/pDraw.class.php
@@ -2549,6 +2549,8 @@
    function modulo($Value1,$Value2)
     {
      if (floor($Value2) == 0) { return(0); }
+     // to evade zero division due to huge $Value2 >= 18446744073709550592
+     if ($Value1 > $Value2) { return(0); }
      if (floor($Value2) != 0) { return($Value1 % $Value2); }
 
      $MinValue = min($Value1,$Value2); $Factor = 10;


### PR DESCRIPTION
I encountered lots of following PHP warning in pandora_console.log

`PHP Warning: Division by zero in /path/to/pandora_console/include/graphs/pChart/pDraw.class.php on line 2552`

I tried out and the following code reproduce this warning with giving huge `$Value2` >= `18446744073709550592` (= `2**64 - 2*10`).

``` php
<?php
ini_set('display_errors','On');
$Value1 = 0;
$Value2 = 18446744073709550592;
$Value1 % $Value2;
?>
```

It seems overflow has occurred, so one may find this warning with less $Value2 on 32-bit systems.

This is a problem of [pChart](http://pchart.net) rather pandorafms, but concerned code still exists on latest pChart.
Therefore I add an workaround patch and sending this pull request.

I found similar problem has reported on [pChart forum](http://wiki.pchart.net/forum/viewtopic.php?f=5&t=190), and reported on it.
