### PR TITLE
Log plugin stderr and improve eventlog performance

### DIFF
--- a/pandora_agents/win32/modules/pandora_module_logevent.cc
+++ b/pandora_agents/win32/modules/pandora_module_logevent.cc
@@ -557,7 +557,7 @@ Pandora_Module_Logevent::getEventDescriptionXPATH (PEVENTLOGRECORD pevlr) {
 	wstring pwsPath;
 	EVT_HANDLE hEvents[1];
 	DWORD dwReturned = 0;
-	LPWSTR ppValues[] = {L"Event/System/Provider/@Name"};
+	LPCWSTR ppValues[] = {L"Event/System/Provider/@Name"};
 	DWORD count = sizeof(ppValues)/sizeof(LPWSTR);
 	EVT_HANDLE hContext = NULL;
 	PEVT_VARIANT pRenderedValues = NULL;

--- a/pandora_agents/win32/modules/pandora_module_logevent.cc
+++ b/pandora_agents/win32/modules/pandora_module_logevent.cc
@@ -321,93 +321,95 @@ Pandora_Module_Logevent::getLogEvents (list<string> &event_list, unsigned char d
 
 		// Process read events
 		while (read > 0) {           
-	    
-			// Retrieve the event description (LOAD_LIBRARY_AS_IMAGE_RESOURCE | LOAD_LIBRARY_AS_DATAFILE)
-			description = getEventDescriptionXPATH (pevlr);
-			if (description == "") {				
-				getEventDescription (pevlr, message, 0x20 | 0x02);
-				if (message[0] == '\0') {
-					// Retrieve the event description (DONT_RESOLVE_DLL_REFERENCES)
-					getEventDescription (pevlr, message, DONT_RESOLVE_DLL_REFERENCES);
+
+			// Filter the event
+			if (filterEvent (pevlr) == 0) {
+			
+				// Retrieve the event description (LOAD_LIBRARY_AS_IMAGE_RESOURCE | LOAD_LIBRARY_AS_DATAFILE)
+				description = getEventDescriptionXPATH (pevlr);
+				if (description == "") {				
+					getEventDescription (pevlr, message, 0x20 | 0x02);
 					if (message[0] == '\0') {
-						description = "N/A";
+						// Retrieve the event description (DONT_RESOLVE_DLL_REFERENCES)
+						getEventDescription (pevlr, message, DONT_RESOLVE_DLL_REFERENCES);
+						if (message[0] == '\0') {
+							description = "N/A";
+						} else {
+							description = message;
+						}
 					} else {
 						description = message;
 					}
-				} else {
-					description = message;
 				}
-			}
-
-			// Filter the event
-			if (filterEvent (pevlr, description) == 0) {
-			
-			    // Generate a timestamp for the event
-			    epoch = pevlr->TimeGenerated;
-			    time_info = localtime (&epoch);
-			    strftime (timestamp, TIMESTAMP_LEN + 1, "%Y-%m-%d %H:%M:%S", time_info);
-
-
-				// Print the event timestamp
-			    std::stringstream event;
-				event << timestamp;
-				
-				// Print additional information for log modules
-			    if (this->getModuleType() == TYPE_LOG) {
-				
-					// Add the timestamp to the log (the previous timestamp will be stripped)
-					event << "[Timestamp: ";
+	
+				if (filterEventDescription (pevlr, description) == 0) {
+				    // Generate a timestamp for the event
+				    epoch = pevlr->TimeGenerated;
+				    time_info = localtime (&epoch);
+				    strftime (timestamp, TIMESTAMP_LEN + 1, "%Y-%m-%d %H:%M:%S", time_info);
+	
+	
+					// Print the event timestamp
+				    std::stringstream event;
 					event << timestamp;
-					event << "]";
 					
-					// Retrieve the event id
-				    event << "[ID: ";
-				    event << (pevlr->EventID & 0x3FFFFFFF);
-					event << "]";
+					// Print additional information for log modules
+				    if (this->getModuleType() == TYPE_LOG) {
 					
-					// Retrieve the source name
-					offset = sizeof(EVENTLOGRECORD);
-					event << " [Source: ";
-					event << (LPTSTR)((LPBYTE)pevlr + offset);
-					event << "]";
-					
-					// Retrieve the computer name
-					offset += strlen((LPTSTR)((LPBYTE)pevlr + offset)) + sizeof(TCHAR);
-					event << " [Computer: ";
-					event << (LPTSTR)((LPBYTE)pevlr + offset);
-					event << "]";
-					
-					// Retrieve the user name
-					event << " [User: ";
-					if(pevlr->UserSidLength > 0) {
-						if (LookupAccountSid(0, (PSID)((LPBYTE)pevlr + pevlr->UserSidOffset),
-	                        lp_name, &cch_name, lp_referenced_domain_name, &cch_referenced_domain_name, &pe_use) != 0) {
-							event << lp_name;	
+						// Add the timestamp to the log (the previous timestamp will be stripped)
+						event << "[Timestamp: ";
+						event << timestamp;
+						event << "]";
+						
+						// Retrieve the event id
+					    event << "[ID: ";
+					    event << (pevlr->EventID & 0x3FFFFFFF);
+						event << "]";
+						
+						// Retrieve the source name
+						offset = sizeof(EVENTLOGRECORD);
+						event << " [Source: ";
+						event << (LPTSTR)((LPBYTE)pevlr + offset);
+						event << "]";
+						
+						// Retrieve the computer name
+						offset += strlen((LPTSTR)((LPBYTE)pevlr + offset)) + sizeof(TCHAR);
+						event << " [Computer: ";
+						event << (LPTSTR)((LPBYTE)pevlr + offset);
+						event << "]";
+						
+						// Retrieve the user name
+						event << " [User: ";
+						if(pevlr->UserSidLength > 0) {
+							if (LookupAccountSid(0, (PSID)((LPBYTE)pevlr + pevlr->UserSidOffset),
+		                        lp_name, &cch_name, lp_referenced_domain_name, &cch_referenced_domain_name, &pe_use) != 0) {
+								event << lp_name;	
+							} else {
+								event << "N/A";
+							}
 						} else {
 							event << "N/A";
 						}
-					} else {
-						event << "N/A";
+						event << "]";						
 					}
-					event << "]";						
-				}
-				
-				
-				// Remove carriage returns and new lines in between the description.
-				output = "";
-				for (size_t i = 0; i < description.size(); i++) {
-					if (description[i] != '\n' && description[i] != '\r') {
-						output += description[i];
+					
+					
+					// Remove carriage returns and new lines in between the description.
+					output = "";
+					for (size_t i = 0; i < description.size(); i++) {
+						if (description[i] != '\n' && description[i] != '\r') {
+							output += description[i];
+						}
 					}
+					output += '\n';
+	
+					// Print the event description
+					event << " ";
+					event << output;
+				     
+				    // Add the event to the list
+				    event_list.push_back (event.str());
 				}
-				output += '\n';
-
-				// Print the event description
-				event << " ";
-				event << output;
-			     
-			    // Add the event to the list
-			    event_list.push_back (event.str());
 			}
 
 			// Move to the next event
@@ -714,7 +716,7 @@ Pandora_Module_Logevent::GetMessageString(EVT_HANDLE hMetadata, EVT_HANDLE hEven
  * @return Returns 0 if the event matches the filters, -1 otherwise.
  */
 int
-Pandora_Module_Logevent::filterEvent (PEVENTLOGRECORD pevlr, string description) {
+Pandora_Module_Logevent::filterEvent (PEVENTLOGRECORD pevlr) {
     LPCSTR source_name;
 
     // Event ID filter
@@ -732,7 +734,20 @@ Pandora_Module_Logevent::filterEvent (PEVENTLOGRECORD pevlr, string description)
     if (! this->application.empty () && this->application.compare (source_name) != 0) {
         return -1;
     }
+    
+    return 0;
+}
 
+
+/**
+ * Filters the given event according to the module parameters.
+ *
+ * @param event Event log record.
+ * @param event Event description.22
+ * @return Returns 0 if the event matches the filters, -1 otherwise.
+ */
+int
+Pandora_Module_Logevent::filterEventDescription (PEVENTLOGRECORD pevlr, string description) {
     // Pattern filter
     if (! this->pattern.empty () && regexec (&this->regexp, description.c_str (), 0, NULL, 0) != 0) {
         return -1;
@@ -740,3 +755,4 @@ Pandora_Module_Logevent::filterEvent (PEVENTLOGRECORD pevlr, string description)
     
     return 0;
 }
+

--- a/pandora_agents/win32/modules/pandora_module_logevent.h
+++ b/pandora_agents/win32/modules/pandora_module_logevent.h
@@ -73,7 +73,8 @@ namespace Pandora_Modules {
         void timestampToSystemtime (string timestamp, SYSTEMTIME *system_time);
         void getEventDescription (PEVENTLOGRECORD pevlr, char *message, DWORD flags);
 		string getEventDescriptionXPATH (PEVENTLOGRECORD pevlr);
-        int filterEvent (PEVENTLOGRECORD pevlr, string description);
+        int filterEvent (PEVENTLOGRECORD pevlr);
+        int filterEventDescription (PEVENTLOGRECORD pevlr, string description);
 		LPWSTR GetMessageString(EVT_HANDLE hMetadata, EVT_HANDLE hEvent, EVT_FORMAT_MESSAGE_FLAGS FormatId);
 
 	public:

--- a/pandora_agents/win32/pandora_windows_service.cc
+++ b/pandora_agents/win32/pandora_windows_service.cc
@@ -729,10 +729,14 @@ Pandora_Windows_Service::copyTentacleDataFile (string host,
 		      filepath.c_str (), host.c_str ());
 	pandoraDebug ("Command %s", tentacle_cmd.c_str());
 
+	/* Set the working directory of the process. It's "utils" directory
+	   to find the GNU W32 tools */
+	working_dir = getPandoraInstallDir ();
+
 	ZeroMemory (&si, sizeof (si));
 	ZeroMemory (&pi, sizeof (pi));
 	if (CreateProcess (NULL , (CHAR *)tentacle_cmd.c_str (), NULL, NULL, FALSE,
-	    CREATE_NO_WINDOW, NULL, NULL, &si, &pi) == 0) {
+	    CREATE_NO_WINDOW, NULL, working_dir.c_str(), &si, &pi) == 0) {
 		return -1;
 	}
 
@@ -1665,7 +1669,7 @@ Pandora_Windows_Service::sendXml (Pandora_Module_List *modules) {
 	fclose (conf_fh);
 
 	/* Only send if debug is not activated */
-	if (getPandoraDebug () == false) {
+	if (true || getPandoraDebug () == false) {
 		rc = this->copyDataFile (tmp_filename);
         
 		/* Delete the file if successfully copied, buffer disabled or not enough space available */

--- a/pandora_agents/win32/pandora_windows_service.cc
+++ b/pandora_agents/win32/pandora_windows_service.cc
@@ -1669,7 +1669,7 @@ Pandora_Windows_Service::sendXml (Pandora_Module_List *modules) {
 	fclose (conf_fh);
 
 	/* Only send if debug is not activated */
-	if (true || getPandoraDebug () == false) {
+	if (getPandoraDebug () == false) {
 		rc = this->copyDataFile (tmp_filename);
         
 		/* Delete the file if successfully copied, buffer disabled or not enough space available */

--- a/pandora_agents/win32/ssh/libssh2/libssh2.h
+++ b/pandora_agents/win32/ssh/libssh2/libssh2.h
@@ -124,7 +124,6 @@ typedef struct _LIBSSH2_USERAUTH_KBDINT_RESPONSE
 	unsigned int length;
 } LIBSSH2_USERAUTH_KBDINT_RESPONSE;
 
-#define ENOTCONN -40
 /* 'keyboard-interactive' authentication callback */
 #define LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC(name_) void name_(const char* name, int name_len, const char* instruction, int instruction_len, int num_prompts, const LIBSSH2_USERAUTH_KBDINT_PROMPT* prompts, LIBSSH2_USERAUTH_KBDINT_RESPONSE* responses, void **abstract)
 

--- a/pandora_agents/win32/windows_service.cc
+++ b/pandora_agents/win32/windows_service.cc
@@ -38,7 +38,7 @@ static void  SetWindowsServiceStatus             (DWORD dwCurrentState,
 						  DWORD dwWin32ExitCode,
 						  DWORD dwCheckPoint,
 						  DWORD dwWaitHint);
-static void  ErrorStopService                    (LPTSTR lpszAPI);
+static void  ErrorStopService                    (LPCTSTR lpszAPI);
 
 /**
  * Set the values of the service to run.
@@ -553,7 +553,7 @@ SetWindowsServiceStatus (DWORD dwCurrentState, DWORD dwWin32ExitCode,
 }
 
 static void
-ErrorStopService (LPTSTR lpszAPI)
+ErrorStopService (LPCTSTR lpszAPI)
 {
 	TCHAR   buffer[256]  = TEXT("");
 	TCHAR   error[1024]  = TEXT("");


### PR DESCRIPTION
The stderr output from plugins and executed programs is written to the agent log.

The way log events are filtered was split into two steps, this was done because getting the description is a relatively expensive operation so first we do the other checks to see if the log entry is interesting.  If so then the description is retrieved and the final filter check is done.
