### PR TITLE
Fix auto address in unix agent

### DIFF
--- a/pandora_agents/unix/FreeBSD/pandora_agent.conf
+++ b/pandora_agents/unix/FreeBSD/pandora_agent.conf
@@ -21,6 +21,18 @@ interval    	300
 # and does not copy XML to server.
 debug 		0	
 
+# Optional. UDP Server to receive orders from outside
+# By default is disabled, set 1 to enable
+# Set port (41122 by default) 
+# Set address to restrict who can order a agent restart (0.0.0.0 = anybody)
+#
+udp_server 0
+udp_server_port 41122
+udp_server_auth_address 0.0.0.0
+
+#process_xeyes_start xeyes
+#process_xeyes_stop killall xeyes
+
 # By default, agent takes machine name
 #agent_name     adama
 
@@ -37,10 +49,16 @@ debug 		0
 # Group assigned for this agent (descriptive, p.e: Servers)
 group Servers
 
+# address: Enforce to server a ip address to this agent 
+# You can also try to detect the first IP using "auto", for example
+address auto
+# or setting a fixed IP address, like for example:
+#address 192.168.36.73
+
 # Autotime: Enforce to server to ignore timestamp coming from this
 # agent, used when agents has no timer or it's inestable. 1 to enable
 # this feature
-# autotime 1
+#autotime 1
 
 # Timezone offset: Difference with the server timezone
 #timezone_offset 0
@@ -48,6 +66,13 @@ group Servers
 # Agent position paramters
 # Those parameters define the geographical position of the agent 
 
+# gis_exec: Call a script that returns a string with a fixed
+# format of latitude,longitude,altitude
+# i.e.: 41.377,-5.105,2.365
+
+#gis_exec /tmp/gis.sh
+
+# This sets the GIS coordinates as fixed values:
 # latitude 
 #latitude 0
 # longitude
@@ -55,11 +80,11 @@ group Servers
 # altitude
 #altitude 0
 
-#Position description
+#GPS Position description
 #position_description Madrid, centro
 
 # By default agent try to take default encoding defined in host.
-# encoding 	UTF-8
+#encoding 	UTF-8
 
 # Listening TCP port for remote server. By default is 41121 (for tentacle)
 # if you want to use SSH use 22, and FTP uses 21.
@@ -69,27 +94,27 @@ server_port	41121
 transfer_mode tentacle
 
 # Server password (Tentacle or FTP). Leave empty for no password (default).
-# server_pwd mypassword
+#server_pwd mypassword
 
 # Set to yes/no to enable/disable OpenSSL support for Tentacle (disabled by default).
-# server_ssl no
+#server_ssl no
 
 # Extra options for the Tentacle client (for example, server_opts "-v -r 5").
-# server_opts
+#server_opts
 
 # delayed_startup defines number of seconds before start execution
 # for first time when startup Pandora FMS Agent
-# delayed_startup 10
+#delayed_startup 10
 
 # Pandora nice defines priority of execution. Less priority means more intensive execution
 # A recommended value is 10. 0 priority means no Pandora CPU protection enabled (default)
-# pandora_nice 0
+#pandora_nice 0
 
 # Cron mode replace Pandora FMS own task schedule each XX interval seconds by the use
 # of old style cron. You should add to crontab Pandora FMS agent script to use this mode.
 # This is disabled by default, and is not recommended.  Use Pandora FMS internal scheduler
 # is much more safe.
-# cron_mode 
+#cron_mode 
 
 # If set to 1 allows the agent to be configured via the web console (Only Enterprise version) 
 # remote_config 1
@@ -109,20 +134,28 @@ transfer_mode tentacle
 # User the agent will run as
 #pandora_user root
 
+# Enable or disable XML buffer.
+# If you are in a secured environment and want to enable the XML buffer you
+# should consider changing the temporal directory, since /tmp is world writable.
+#xml_buffer 1
+
+# Minimum available bytes in the temporal directory to enable the XML buffer
+temporal_min_size 1024
+
 # Secondary server configuration
 # ==============================
 
 # If secondary_mode is set to on_error, data files are copied to the secondary
 # server only if the primary server fails. If set to always, data files are
 # always copied to the secondary server.
-# secondary_mode on_error
-# secondary_server_ip localhost
-# secondary_server_path /var/spool/pandora/data_in
-# secondary_server_port 41121
-# secondary_transfer_mode tentacle
-# secondary_server_pwd mypassword
-# secondary_server_ssl no
-# secondary_server_opts
+#secondary_mode on_error
+#secondary_server_ip localhost
+#secondary_server_path /var/spool/pandora/data_in
+#secondary_server_port 41121
+#secondary_transfer_mode tentacle
+#secondary_server_pwd mypassword
+#secondary_server_ssl no
+#secondary_server_opts
 
 # Module Definition
 # =================

--- a/pandora_agents/unix/pandora_agent
+++ b/pandora_agents/unix/pandora_agent
@@ -2208,20 +2208,11 @@ while (1) {
 	if(defined($Conf{'address'})) {
 		# Check if address is auto to get the local ip
 		if ($Conf{'address'} eq 'auto') {
-			# Tested on Ubuntu, debian, Suse, Solaris 10 and AIX 5.1
-			my @address_list = `ifconfig -a 2>$DevNull | grep -v '127.0.0' | grep '[0-9]*\\.[0-9]*\\.[0-9]*' | awk '{ print \$2 }' | awk -F':' '{ print \$2 }'`;
-			if ($#address_list < 0) {
-				# Tested on Red Hat 7
-				@address_list = `ip addr show 2>$DevNull | grep -v '127.0.0' | grep '[0-9]*\\.[0-9]*\\.[0-9]*' | awk '{print \$2}' | cut -d/ -f1`;
-			}
-			for (my $i = 0; $i <= $#address_list; $i++) {		
-				chomp($address_list[$i]);
-				if ($i > 0) {
-					$address .= ',';
-				}
-				
-				$address .= $address_list[$i];
-			}			
+			# Tested on Ubuntu 12.04.5 and 14.04.2, Debian 7.8 and 8.0, CentOS 6.6 and 7.0, FreeBSD 10, Fedora 21
+			my @address_list = `ifconfig -a 2>$DevNull | sed -nE 's/^.*inet (addr:)?([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+).*\$/\\2/p' | grep -v '^127\\..*'`;
+			my @ipv6_address_list = `ifconfig -a 2>$DevNull | sed -nE 's/^[[:space:]]+inet6 (addr: )?([0-9a-fA-F:]+).*(prefixlen [0-9]+ *|scopeid 0x0<global>|Scope:Global)\$/\\2/p' | grep -v '^::1\$'`;
+			chomp (@address_list, @ipv6_address_list);
+			$address = join(',', @address_list, @ipv6_address_list);
 		}
 		else {
 			$address = $Conf{'address'};

--- a/pandora_agents/unix/pandora_agent
+++ b/pandora_agents/unix/pandora_agent
@@ -2210,7 +2210,7 @@ while (1) {
 		if ($Conf{'address'} eq 'auto') {
 			# Tested on Ubuntu 12.04.5 and 14.04.2, Debian 7.8 and 8.0, CentOS 6.6 and 7.0, FreeBSD 10, Fedora 21
 			my @address_list = `ifconfig -a 2>$DevNull | sed -nE 's/^.*inet (addr:)?([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+).*\$/\\2/p' | grep -v '^127\\..*'`;
-			my @ipv6_address_list = `ifconfig -a 2>$DevNull | sed -nE 's/^[[:space:]]+inet6 (addr: )?([0-9a-fA-F:]+).*(prefixlen [0-9]+ *|scopeid 0x0<global>|Scope:Global)\$/\\2/p' | grep -v '^::1\$'`;
+			my @ipv6_address_list = `ifconfig -a 2>$DevNull | sed -nE 's/^[[:space:]]+inet6 (addr: )?([0-9a-fA-F:]+).*(prefixlen [0-9]+( autoconf)? *|scopeid 0x0<global>|Scope:Global)\$/\\2/p' | grep -v '^::1\$'`;
 			chomp (@address_list, @ipv6_address_list);
 			$address = join(',', @address_list, @ipv6_address_list);
 		}


### PR DESCRIPTION
Fixes auto agent address so it works on more platforms. This has been tested on
CentOS 6.6 and 7, Debian 7.8 and 8.0, Fedora 21, FreeBSD 10, Ubuntu 12.04.5 and
14.04.2.  The previous code failed on CentOS 7, Fedora and FreeBSD.

Add reporting of IPv6 global addresses.
