### PR TITLE
Don't remove build machine's pandora_agent.conf

### DIFF
--- a/pandora_agents/unix/pandora_agent.redhat.spec
+++ b/pandora_agents/unix/pandora_agent.redhat.spec
@@ -51,11 +51,6 @@ cp -aRf $RPM_BUILD_ROOT%{prefix}/pandora_agent/pandora_agent_daemon $RPM_BUILD_R
 cp -aRf $RPM_BUILD_ROOT%{prefix}/pandora_agent/man/man1/pandora_agent.1.gz $RPM_BUILD_ROOT/usr/share/man/man1/
 cp -aRf $RPM_BUILD_ROOT%{prefix}/pandora_agent/man/man1/tentacle_client.1.gz $RPM_BUILD_ROOT/usr/share/man/man1/
 
-# Checking old config file (if exists)
-if [ -f /etc/pandora/pandora_agent.conf ] ; then
-	mv /etc/pandora/pandora_agent.conf /etc/pandora/pandora_agent.conf.backup
-fi
-
 cp -aRf $RPM_BUILD_ROOT%{prefix}/pandora_agent/Linux/pandora_agent.conf $RPM_BUILD_ROOT/usr/share/pandora_agent/pandora_agent.conf.rpmnew
 
 if [ -f $RPM_BUILD_ROOT%{prefix}/pandora_agent/pandora_agent.spec ] ; then

--- a/pandora_agents/unix/pandora_agent.spec
+++ b/pandora_agents/unix/pandora_agent.spec
@@ -51,11 +51,6 @@ cp -aRf $RPM_BUILD_ROOT%{prefix}/pandora_agent/pandora_agent_daemon $RPM_BUILD_R
 cp -aRf $RPM_BUILD_ROOT%{prefix}/pandora_agent/man/man1/pandora_agent.1.gz $RPM_BUILD_ROOT/usr/share/man/man1/
 cp -aRf $RPM_BUILD_ROOT%{prefix}/pandora_agent/man/man1/tentacle_client.1.gz $RPM_BUILD_ROOT/usr/share/man/man1/
 
-# Checking old config file (if exists)
-if [ -f /etc/pandora/pandora_agent.conf ] ; then
-	mv /etc/pandora/pandora_agent.conf /etc/pandora/pandora_agent.conf.backup
-fi
-
 cp -aRf $RPM_BUILD_ROOT%{prefix}/pandora_agent/Linux/pandora_agent.conf $RPM_BUILD_ROOT/usr/share/pandora_agent/pandora_agent.conf.rpmnew
 
 if [ -f $RPM_BUILD_ROOT%{prefix}/pandora_agent/pandora_agent.spec ] ; then

--- a/pandora_server/pandora_server.redhat.spec
+++ b/pandora_server/pandora_server.redhat.spec
@@ -83,7 +83,7 @@ install -m 0640 conf/pandora_server.conf.new $RPM_BUILD_ROOT%{_sysconfdir}/pando
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/sudoers.d
 chmod 0750 $RPM_BUILD_ROOT%{_sysconfdir}/sudoers.d
 cat <<EOF > $RPM_BUILD_ROOT%{_sysconfdir}/sudoers.d/pandora
-Defaults:pandora !requiretty
+Defaults:root !requiretty
 EOF
 chmod 0440 $RPM_BUILD_ROOT%{_sysconfdir}/sudoers.d/pandora
 


### PR DESCRIPTION
When you build the RPMs the build machine's pandora_agent.conf gets renamed to pandora_agent.conf.backup.  I don't think that was the intent and certainly not desirable. :-)

Also the automatic start of the tentacle server was failing on CentOS 7 because there was no tty.  There was a sudoers configuration file which was supposed to fix that but it had the new user not the one running sudo.
