### PR TITLE
Fix two SSL issues

### DIFF
--- a/pandora_agents/unix/tentacle_client
+++ b/pandora_agents/unix/tentacle_client
@@ -407,6 +407,7 @@ sub start_ssl {
 	if ($t_ssl_cert eq ''){
 		IO::Socket::SSL->start_SSL (
 			$t_socket,
+			SSL_verify_mode => '0x00',
 		);
 	}
 	elsif ($t_ssl_ca eq '') {

--- a/pandora_server/bin/tentacle_server
+++ b/pandora_server/bin/tentacle_server
@@ -736,6 +736,9 @@ sub accept_connections {
 sub serve_client() {
 
 	eval {		
+		local $SIG{__DIE__} = sub {
+			print STDERR $_[0];
+		};
 		# Add client socket to select queue
 		$t_select = IO::Select->new ();
 		$t_select->add ($t_client_socket);


### PR DESCRIPTION
Current versions of IO::Socket::SSL default to verify peer in the client.  This turns off that verification when just -c is specified.
