### PR TITLE
IO-wait cpu ticks is a discrete value not cumulative

### DIFF
--- a/pandora_agents/unix/Linux/pandora_agent.conf
+++ b/pandora_agents/unix/Linux/pandora_agent.conf
@@ -205,7 +205,7 @@ module_end
 #IO Wait CPU ticks /sec
 module_begin 
 module_name IOWaitCPU
-module_type generic_data_inc
+module_type generic_data
 module_exec vmstat -s | grep "IO-wait cpu ticks" | awk '{ print $1 }'
 module_unit ticks/sec
 module_description Too much IOwait means IO bottleneck and performance problems. Check also LoadAVG.


### PR DESCRIPTION
That's borne out by the 100s of Received invalid data messages in the logs. :-)
