### PR TITLE
Pandora unix agent bug fixes

### DIFF
--- a/pandora_agents/unix/pandora_agent
+++ b/pandora_agents/unix/pandora_agent
@@ -510,6 +510,9 @@ sub parse_conf_modules($) {
 				# Make the module run the first time
 				$module->{'counter'} = $module->{'intensive_interval'};
 							
+				# Replace macros
+				replace_macros ($module);
+
 				push (@Modules, {%{$module}});
 			} else {
 				$module->{'func'} = \&module_plugin;
@@ -601,7 +604,7 @@ sub write_broker_conf($){
 	my ($broker_agent) = @_;
 	my $content = '';
 
-	# I don't think the following should be copied either: proxy_*, secondary_* 
+	# I don't think the following should be copied either: proxy_*
 	my %ignored_tokens = (
 		'broker_agent' => 1, 'agent_name_cmd' => 1, 'udp_server' => 1, 'cron_mode' => 1
 	);

--- a/pandora_agents/unix/pandora_agent
+++ b/pandora_agents/unix/pandora_agent
@@ -601,16 +601,20 @@ sub write_broker_conf($){
 	my ($broker_agent) = @_;
 	my $content = '';
 
+	# I don't think the following should be copied either: proxy_*, secondary_* 
+	my %ignored_tokens = (
+		'broker_agent' => 1, 'agent_name_cmd' => 1, 'udp_server' => 1, 'cron_mode' => 1
+	);
+
 	open (CONF_FILE, "$ConfDir/$ConfFile") or error ("Could not open file '$ConfDir/$ConfFile': $!.");
 	open (BROKER_FILE, ">$ConfDir/${broker_agent}.conf") or error ("Could not write configuration file: $!");
 
-	while (my $line = <CONF_FILE>){
+	while (my $line = <CONF_FILE>) {
 
-		# Skip broker definitions
-		if ($line =~ m/^\s*broker_agent/) {
-			next;
-		}
-		
+		my ( $token ) = $line =~ m/^\s*(\S+)(\s.*)?$/;
+		# Skip tokens which should not be copied to broker configuration
+		next if defined $ignored_tokens{$token};
+
 		# Change the agent name
 		if ($line =~ m/^\s*#*\s*agent_name\s+/) {
 			$line = "agent_name $broker_agent\n";
@@ -647,19 +651,6 @@ sub read_config (;$) {
 		# Replace CRLF with LF
 		$line =~ s/\r\n/\n/g;
 		
-		# Store the custom fields
-		
-		if (($line =~ m/^(custom_field\d+_name)\s+(.*)/) or ($line =~ m/^(custom_field\d+_value)\s+(.*)/)) {
-			$Customfields{$1} = $2;
-			next;
-		}
-
-		# Save global macros
-		if ($line =~ m/^macro(\S+)\s+(.*)/) {
-			$Macros{$1} = $2;
-			next;
-		}
-		
 		# Token search
 		if (defined ($token)) {
 			if ($line =~ /^\s*(\S+)\s+(.*)$/ && $1 eq $token) {
@@ -675,6 +666,20 @@ sub read_config (;$) {
 			}
 			next;
 		}
+
+		# Store the custom fields
+		
+		if (($line =~ m/^(custom_field\d+_name)\s+(.*)/) or ($line =~ m/^(custom_field\d+_value)\s+(.*)/)) {
+			$Customfields{$1} = $2;
+			next;
+		}
+
+		# Save global macros
+		if ($line =~ m/^macro(\S+)\s+(.*)/) {
+			$Macros{$1} = $2;
+			next;
+		}
+		
 		next if ($line =~ /^module\s*\w*/);
 
 		#Configuration token
@@ -872,7 +877,7 @@ sub send_buffered_xml_files () {
 	while (my $xml_file = readdir(TEMPORAL)) { 
 	
 		# Skip non data files and symlinks
-		next if ($xml_file !~ m/\.data$/ || -l "$Conf{'temporal'}/$xml_file");
+		next if ($xml_file !~ m/^$Conf{'agent_name'}\.[0-9]+\.data$/ || -l "$Conf{'temporal'}/$xml_file");
 
 		my $rc = send_file ("$Conf{'temporal'}/$xml_file", 1);
 		unlink ("$Conf{'temporal'}/$xml_file") if ($rc == 0);


### PR DESCRIPTION
Add additional settings that aren't copied to a broker_agent conf.

Don't reprocess the custom_fields and global macros every time the conf
is searched for a specific item.

Be more specific about the files copied by xml_buffer, ensuring they
have the right name format.

Replace global macros in single line module_plugin statements.
