### PR TITLE
Fix CentOS / RHEL version detection

### DIFF
--- a/pandora_agents/unix/pandora_agent
+++ b/pandora_agents/unix/pandora_agent
@@ -1228,6 +1228,12 @@ sub guess_os_version ($) {
 	# Linux
 	if ($os eq 'linux') {
 		$os_version = `lsb_release -sd 2>$DevNull`;
+		if ($os_version) {
+			$os_version =~ s/^\s*\"(.*)\"\s*$/$1/;
+		} elsif (-f '/etc/redhat-release') {
+			$os_version = `head -1 /etc/redhat-release`;
+		}
+		$os_version =~ s/^\s*|\s*$//g;
 	# AIX
 	} elsif ($os eq 'aix') {
 		$os_version = "$2.$1" if (`uname -rv` =~ /\s*(\d)\s+(\d)\s*/);


### PR DESCRIPTION
This change fixes three issues with version detection on RHEL distros.

First lsb_release -sd wraps the response in quotes.  This happens on
both CentOS 6.x and 7.x.

Second CentOS 7 (and probably RHEL 7) don't install the package with
lsb_release by default so this change gets the information from
/etc/redhat-release if lsb_release doesn't return anything.

Finally there are extra spaces at the end of the string.
