### PR TITLE
Updated to have Windows' module_service return 0 or 1.

### DIFF
--- a/pandora_agents/win32/windows/pandora_wmi.cc
+++ b/pandora_agents/win32/windows/pandora_wmi.cc
@@ -116,11 +116,8 @@ Pandora_Wmi::isServiceRunning (string service_name) {
 			if (str_state == "Running") {
 				retval = 1;
 			}
-			else if (str_state == "Stopped") {
-				retval = 0;
-			}
 			else {
-				retval = -1;
+				retval = 0;
 			}
 			dhFreeString (state);
 


### PR DESCRIPTION
Windows' module_service is treated as boolean module (module_type =
generic_proc), but it could return -1 in case of "Start Pending",
"Stop Pending", and so on.

Our case is;
- the service terminated unexpectedly
- Pandora FMS detected Error Event (ID:7034 Source:Service Control Manager)
- The corresponding Service module went -1, but it was not detected
  (because of generic_proc module)

So I updated the source to detect such a case via 'module_service' (very simple updates :).

How about that? (If you had some purpose to have module_service return -1, please let me know.)

Thank you.
