### PR TITLE
Update update_manager.ajax.php

### DIFF
--- a/pandora_console/include/ajax/update_manager.ajax.php
+++ b/pandora_console/include/ajax/update_manager.ajax.php
@@ -353,6 +353,16 @@ if ($update_last_free_package) {
 	//curl_setopt($curlObj, CURLOPT_POST, true);
 	//curl_setopt($curlObj, CURLOPT_POSTFIELDS, $params);
 	curl_setopt($curlObj, CURLOPT_SSL_VERIFYPEER, false);
+	if (isset($config['update_manager_proxy_server'])) {
+		curl_setopt($curlObj, CURLOPT_PROXY, $config['update_manager_proxy_server']);
+	}
+	if (isset($config['update_manager_proxy_port'])) {
+		curl_setopt($curlObj, CURLOPT_PROXYPORT, $config['update_manager_proxy_port']);
+	}
+	if (isset($config['update_manager_proxy_user'])) {
+		curl_setopt($curlObj, CURLOPT_PROXYUSERPWD, $config['update_manager_proxy_user'] . ':' . $config['update_manager_proxy_password']);
+	}
+	
 	$result = curl_exec($curlObj);
 	$http_status = curl_getinfo($curlObj, CURLINFO_HTTP_CODE);
 	


### PR DESCRIPTION
This would be to include proxy configuration in the downloading of updates process. Without this Proxy information the update manager will work to check for downloads, but the actual download does not respect the proxy settings.
