### PR TITLE
Added enable/disable toggle for 'Throw unknown event' at 'Setup’

### DIFF
--- a/pandora_console/godmode/setup/setup_general.php
+++ b/pandora_console/godmode/setup/setup_general.php
@@ -277,6 +277,12 @@ $table->data[34][0] = __('Limit parameters massive') .
 $table->data[34][1] = html_print_input_text('limit_parameters_massive',
 	$config['limit_parameters_massive'], '', 10, 10, true);
 
+# unknown event
+$config["throw_unknown_events"] = isset($config["throw_unknown_events"]) ? $config["throw_unknown_events"] : 1;
+$table->data[35][0] = __('Throw unknown events') .
+	ui_print_help_tip(__('Unknown events would be thrown when the module is in unknown status'), true);
+$table->data[35][1] = __('Yes').'&nbsp;&nbsp;&nbsp;'.html_print_radio_button ('throw_unknown_events', 1, '', $config["throw_unknown_events"], true).'&nbsp;&nbsp;';
+$table->data[35][1] .= __('No').'&nbsp;&nbsp;&nbsp;'.html_print_radio_button ('throw_unknown_events', 0, '', $config["throw_unknown_events"], true);
 
 echo '<form id="form_setup" method="post" action="index.php?sec=gsetup&sec2=godmode/setup/setup&amp;section=general&amp;pure='.$config['pure'].'">';
 

--- a/pandora_console/include/functions_config.php
+++ b/pandora_console/include/functions_config.php
@@ -201,6 +201,8 @@ function config_update_config () {
 						$error_update[] = __('Allow create planned downtimes in the past');
 					if (!config_update_value ('limit_parameters_massive', get_parameter('limit_parameters_massive')))
 						$error_update[] = __('Limit parameters massive');
+					if (!config_update_value ('throw_unknown_events', get_parameter('throw_unknown_events')))
+						$error_update[] = __('Unknown events would be thrown when the module is in unknown status');
 					break;
 				case 'enterprise':
 					if (isset($config['enterprise_installed']) && $config['enterprise_installed'] == 1) {

--- a/pandora_server/lib/PandoraFMS/Core.pm
+++ b/pandora_server/lib/PandoraFMS/Core.pm
@@ -3742,15 +3742,23 @@ sub generate_status_event ($$$$$$$$) {
 	}
 
 	# disable event just recovering from 'Unknown' without status change
-	if($last_status == 3 && $status == $last_known_status && $module->{'disabled_types_event'} ) {
-		my $disabled_types_event;
-		eval {
-			local $SIG{__DIE__};
-			$disabled_types_event = decode_json($module->{'disabled_types_event'});
-		};
-		
-		if ($disabled_types_event->{'going_unknown'}) {
+	if($last_status == 3 && $status == $last_known_status ) {
+
+		if (! pandora_get_config_throw_unknown_events($dbh, $agent, $module) ) {
 			return;
+		}
+
+		if($module->{'disabled_types_event'} ) {
+
+			my $disabled_types_event;
+			eval {
+				local $SIG{__DIE__};
+				$disabled_types_event = decode_json($module->{'disabled_types_event'});
+			};
+			
+			if ($disabled_types_event->{'going_unknown'}) {
+				return;
+			}
 		}
 	}
 
@@ -3809,6 +3817,19 @@ sub generate_status_event ($$$$$$$$) {
 	}
 
 }
+
+##########################################################################
+## Return if unknown event should be thrown
+###########################################################################
+sub pandora_get_config_throw_unknown_events($$$)
+{
+	my ($dbh, $agent, $module) = @_;
+
+	my $config_throw_unknown_events = pandora_get_config_value($dbh, 'throw_unknown_events');
+
+	return ($config_throw_unknown_events ne "" ? $config_throw_unknown_events : 1);
+}
+
 
 ##########################################################################
 # Saves module data to the DB.
@@ -4541,7 +4562,10 @@ sub pandora_module_unknown ($$) {
 			}
 			
 			my $do_event = 0;
-			if (!defined($module->{'disabled_types_event'}) || $module->{'disabled_types_event'} eq "") {
+			if (! pandora_get_config_throw_unknown_events($dbh, $agent, $module) ) {
+				$do_event = 0;
+			}
+			elsif (!defined($module->{'disabled_types_event'}) || $module->{'disabled_types_event'} eq "") {
 				$do_event = 1;
 			}
 			else {


### PR DESCRIPTION
We faced a case that a lot of 'going_unknown' events (and its
respective recoveries) were thrown and they caused bad Console
performance at some environment.
In such case, disabling 'going unknown event' could work.
