### PR TITLE
added net-snmp-utils to Dockerfile

### DIFF
--- a/pandora_console/Dockerfile
+++ b/pandora_console/Dockerfile
@@ -45,6 +45,7 @@ RUN yum install -y \
 	php-common \ 
 	php-zip \ 
 	nmap \
+	net-snmp-utils \
 	xprobe2
 
 #Clone the repo


### PR DESCRIPTION
pandora-console required net-snmp-utils to run SNMP wizard from web console.
