### PR TITLE
Allow pre-shipping of an empty config.php

### DIFF
--- a/pandora_console/install.php
+++ b/pandora_console/install.php
@@ -355,7 +355,7 @@ function install_step1() {
 			<p>For more information, please refer to documentation.<br>
 			<i>Pandora FMS Development Team</i></p>
 		";
-		if (file_exists("include/config.php")) {
+		if (file_exists("include/config.php") && (filesize("include/config.php") > 0)) {
 			echo "<div class='warn'><b>Warning:</b> You already have a config.php file. 
 			Configuration and database would be overwritten if you continued.</div>";
 		}


### PR DESCRIPTION
Disable the warning displayed by the installer when checking for existing configs. Zero bytes = no danger overwriting. This enables a better user experience when handling a pre-shipped, zero bytes config.php.