### PR TITLE
Adding a check for HTTP_X_FORWARDED_PROTO in https_is_running()

### DIFF
--- a/pandora_console/include/functions.php
+++ b/pandora_console/include/functions.php
@@ -69,6 +69,10 @@ require_once('functions_io.php');
 //}
 
 function https_is_running() {
+	if(isset ($_SERVER['HTTP_X_FORWARDED_PROTO'])
+		&& $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+		return true;
+	}
 	if (isset ($_SERVER['HTTPS'])
 		&& ($_SERVER['HTTPS'] === true
 		|| $_SERVER['HTTPS'] == 'on')) {

--- a/pandora_console/include/functions_ui.php
+++ b/pandora_console/include/functions_ui.php
@@ -2325,6 +2325,10 @@ function ui_get_full_url ($url = '', $no_proxy = false, $add_name_php_file = fal
 	$port = null;   // null means 'use the starndard port'
 	$proxy = false; //By default Pandora FMS doesn't run across proxy.
 	
+	if(isset ($_SERVER['HTTP_X_FORWARDED_PROTO'])
+		&& $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+		$_SERVER['HTTPS'] = 'on';
+	}
 	if (isset ($_SERVER['HTTPS'])
 		&& ($_SERVER['HTTPS'] === true
 		|| $_SERVER['HTTPS'] == 'on')) {


### PR DESCRIPTION
When behind an HTTPS proxy, `$_SERVER['HTTPS']` is not automatically set, so `https_is_running()` does not function appropriately.

Instead, checking for `$_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'` is required.

This is even more critically important for supporting HTTPS when apache in the docker container doesn't actually support being configured with HTTPS.

We are building from our own forked tree with this PR applied. The repo managing that docker image build is here:
- https://github.com/sofwerx/docker-pandorafms

We have this deployed behind a traefik proxy, as is orchestrated here:
- https://github.com/sofwerx/swx-devops/tree/master/local/swx-pandora
