### PR TITLE
Fix bug in new agent API

### DIFF
--- a/pandora_console/include/functions_api.php
+++ b/pandora_console/include/functions_api.php
@@ -1967,9 +1967,9 @@ function api_get_all_agents($thrash1, $thrash2, $other, $returnType)
             }
 
             $ag_groups = implode(',', (array) $ag_groups);
+            $where .= ' AND (id_grupo IN ('.$ag_groups.') OR id_group IN ('.$ag_groups.'))';
         }
 
-        $where .= ' AND (id_grupo IN ('.$ag_groups.') OR id_group IN ('.$ag_groups.'))';
     }
 
     if (isset($other['data'][3])) {

--- a/pandora_console/include/functions_api.php
+++ b/pandora_console/include/functions_api.php
@@ -1566,7 +1566,7 @@ function api_set_new_agent($thrash1, $thrash2, $other, $thrash3)
             $exists_ip = db_get_row_sql('SELECT direccion FROM tagente WHERE direccion = "'.$direccion_agente.'"');
         }
 
-        if (!$exists_alias && !$exists_ip) {
+        if (!$exists_alias) {
             $id_agente = db_process_sql_insert(
                 'tagente',
                 [


### PR DESCRIPTION
It is valid to create multiple agents with the same IP address. Remove test that did not allow this.

 In the console, it is perfectly legal (and make sense). For example, creating an agent for each switch port. All the agents will refer to the same switch IP address