### PR TITLE
Make exclusion usable

### DIFF
--- a/pandora_agents/unix/plugins/pandora_df_used
+++ b/pandora_agents/unix/plugins/pandora_df_used
@@ -58,7 +58,7 @@ else
 		if (substr($fs,0,1) eq '-')
 		{
 			my $mount_name=substr($fs,1,);
-			my @mount_all= split /\n/, `df -khTP | tail -n +2 | awk '{print \$7}'| grep -i "$mount_name"`; 
+			my @mount_all= split /\n/, `df -khTP | tail -n +2 | awk '{print $7}'| grep -i "$mount_name"`; 
 			foreach (@mount_all){
 				$excluded_filesystems{$_} = '-1%';
 			}


### PR DESCRIPTION
The parameter "-l FS_TO_EXCLUDE" didn't work

An extra of pug deugger called with

perl -d pandora_df_used -/dev/loop9

BEFORE THE CHANGE
################

root@live:~# perl -d /usr/share/pandora_agent/plugins/pandora_df_used -/dev/loop9
  DB<1> c 61
main::(/usr/share/pandora_agent/plugins/pandora_df_used:61):
61:                             my @mount_all= split /\n/, `df -khTP | tail -n +2 | awk '{print \$7}'| grep -i "$mount_name"`;
  DB<2> n
main::(/usr/share/pandora_agent/plugins/pandora_df_used:62):
62:                             foreach (@mount_all){
  DB<2> n
main::(/usr/share/pandora_agent/plugins/pandora_df_used:79):
79:             my $free;
  DB<2> x @mount_all
  empty array
  
  AFTER THE CHANGE
################

  DB<1> c 61
main::(pandora_df_used:61):                             my @mount_all= split /\n/, `df -khTP | tail -n +2 | awk '{print $7}'| grep -i "$mount_name"`;
  DB<2> n
main::(pandora_df_used:62):                             foreach (@mount_all){
  DB<2> x @mount_all
0  '/dev/loop9                                      squashfs   64M   64M     0 100% /snap/core20/1950'
  DB<3> n
main::(pandora_df_used:63):                                     $excluded_filesystems{$_} = '-1%';
  DB<3> n
main::(pandora_df_used:79):             my $free;
  DB<3> x %excluded_filesystems
0  '/dev/loop9                                      squashfs   64M   64M     0 100% /snap/core20/1950'
1  '-1%'

Manual test
#########

OK df -khTP | tail -n +2 | awk '{print $7}'| grep -i "/dev/loop9"
KO df -khTP | tail -n +2 | awk '{print \$7}'| grep -i "/dev/loop9"

The result of the second command is an error

awk: cmd. line:1: {print \$7}
awk: cmd. line:1:        ^ backslash not last character on line
awk: cmd. line:1: {print \$7}
awk: cmd. line:1:        ^ syntax error
