### PR TITLE
snmp_process.pl: Also report process in state 'runnable' as active (fixes Linux agents).

### DIFF
--- a/pandora_server/util/plugin/snmp_process.pl
+++ b/pandora_server/util/plugin/snmp_process.pl
@@ -122,7 +122,7 @@ sub get_status {
 		
 		chomp($output);
 		
-		if($output eq '1') {
+		if($output =~ /^(1|2)$/ ) {
 			$output = "1\n";
 		}
 		else {


### PR DESCRIPTION
Stock script `pandora_server/util/plugin/snmp_process.pl` has flaw that it reports only state `running(1)`  as active (1) - but under Linux (net-snmp) processes are most of time in  `runnable(2)`  state as defined in MIB:

```
hrSWRunStatus OBJECT-TYPE
    SYNTAX     INTEGER {
                   running(1),
                   runnable(2),    -- waiting for resource
                                   -- (i.e., CPU, memory, IO)
                   notRunnable(3), -- loaded but waiting for event
                   invalid(4)      -- not loaded
               }
    MAX-ACCESS read-write
    STATUS     current
    DESCRIPTION
        "The status of this running piece of software.
        Setting this value to invalid(4) shall cause this
        software to stop running and to be unloaded. Sets to
        other values are not valid."
    ::= { hrSWRunEntry 7 }
```

So proper way is to report both `running(1)` state (all processes under Windows) and `runnable(2)` state (used under Linux with net-snmp) as active.

Below are equivalent SNMP commands showing that under Linux monitored process is rarely in state `1`:
```shell
$ snmpwalk -Os -c public -v 2c deb12-promsnmp.example.com HOST-RESOURCES-MIB::hrSWRunName | grep sshd  | tail -1

hrSWRunName.891 = STRING: "sshd"

$ snmpwalk -Os -c public -v 2c deb12-promsnmp.example.com HOST-RESOURCES-MIB::hrSWRunStatus.891

hrSWRunStatus.891 = INTEGER: runnable(2)
```

And finally example of CLI commands with this patch to verify that `sshd` process is running (in broader sense than just actively using some CPU):
```shell
$ /usr/share/pandora_server/util/plugin/snmp_process.pl  -i 192.168.122.12 -c public -t status -p sshd

1

$ /usr/share/pandora_server/util/plugin/snmp_process.pl  -i 192.168.122.12 -c public -t status -p not-exist

0
```

Without this PR script returns `0` even for `sshd` because it is most of time in state (2).